### PR TITLE
Implicitly transform to SRID of geom column

### DIFF
--- a/vectortiles/postgis/functions.py
+++ b/vectortiles/postgis/functions.py
@@ -15,7 +15,10 @@ class RawGeometryField(GeometryField):
 
 class MakeEnvelope(Func):
     function = "ST_MAKEENVELOPE"
-    output_field = GeometryField()
+
+    def __init__(self, *expressions, output_field=None, **extra):
+        super().__init__(*expressions, output_field=None, **extra)
+        self.output_field = GeometryField(srid=expressions[4])
 
 
 class AsMVTGeom(GeoFunc):

--- a/vectortiles/postgis/mixins.py
+++ b/vectortiles/postgis/mixins.py
@@ -14,8 +14,8 @@ class PostgisBaseVectorTile(BaseVectorTileMixin):
 
         # keep features intersecting tile
         filters = {
-            f"{self.vector_tile_geom_name}__intersects": Transform(MakeEnvelope(xmin, ymin, xmax, ymax, 3857),
-                                                                   4326)
+            # GeoFuncMixin implicitly transforms to SRID of geom
+            f"{self.vector_tile_geom_name}__intersects": MakeEnvelope(xmin, ymin, xmax, ymax, 3857)
         }
         features = features.filter(**filters)
         # annotate prepared geometry for MVT

--- a/vectortiles/tests/test_functions.py
+++ b/vectortiles/tests/test_functions.py
@@ -1,3 +1,4 @@
+from django import VERSION
 from django.test import TestCase
 import mercantile
 from vectortiles.postgis.functions import MakeEnvelope
@@ -7,7 +8,12 @@ from test_vectortiles.test_app.models import Feature
 
 class MakeEnvelopeTestCase(TestCase):
     def test_implicitely_transform_to_base_srid(self):
-        expected_transform = "ST_Transform(ST_MAKEENVELOPE(-20037508.342789244, -20037508.342789244, 20037508.342789244, 20037508.342789244, 3857), 4326)"
+        DJANGO_MAJOR = VERSION[0]
+        if DJANGO_MAJOR < 3:
+            # superfluous parenthesis for unknown reason
+            expected_transform = "ST_Transform((ST_MAKEENVELOPE(-20037508.342789244, -20037508.342789244, 20037508.342789244, 20037508.342789244, 3857)), 4326)"
+        else:
+            expected_transform = "ST_Transform(ST_MAKEENVELOPE(-20037508.342789244, -20037508.342789244, 20037508.342789244, 20037508.342789244, 3857), 4326)"
 
         features = Feature.objects.filter(geom__intersects=MakeEnvelope(*mercantile.xy_bounds(0, 0, 0), 3857))
 

--- a/vectortiles/tests/test_functions.py
+++ b/vectortiles/tests/test_functions.py
@@ -1,0 +1,14 @@
+from django.test import TestCase
+import mercantile
+from vectortiles.postgis.functions import MakeEnvelope
+
+from test_vectortiles.test_app.models import Feature
+
+
+class MakeEnvelopeTestCase(TestCase):
+    def test_implicitely_transform_to_base_srid(self):
+        expected_transform = "ST_Transform(ST_MAKEENVELOPE(-20037508.342789244, -20037508.342789244, 20037508.342789244, 20037508.342789244, 3857), 4326)"
+
+        features = Feature.objects.filter(geom__intersects=MakeEnvelope(*mercantile.xy_bounds(0, 0, 0), 3857))
+
+        self.assertIn(expected_transform, str(features.query))


### PR DESCRIPTION
`MakeEnvelope`'s output geometry needs an SRID. Then `GeoFunc`s like `ST_Intersect` will automatically transform to the SRID of the geometry column.

Fix #3 