### PR TITLE
:feature: Support fetching multiple layers in a single DB trip

### DIFF
--- a/vectortiles/mixins.py
+++ b/vectortiles/mixins.py
@@ -48,6 +48,9 @@ class BaseVectorTileMixin:
         """ Get layer name in tile dynamically """
         return self.vector_tile_layer_name
 
+    def iter_layer_features(self, queryset):
+        yield queryset, self.get_vector_tile_layer_name(), self.vector_tile_fields
+
     def get_tile(self, x, y, z):
         """
         Generate a mapbox vector tile as bytearray

--- a/vectortiles/postgis/mixins.py
+++ b/vectortiles/postgis/mixins.py
@@ -24,20 +24,30 @@ class PostgisBaseVectorTile(BaseVectorTileMixin):
                                                              self.vector_tile_extent,
                                                              self.vector_tile_buffer,
                                                              self.vector_tile_clip_geom))
-        fields = self.vector_tile_fields + ("geom_prepared", ) if self.vector_tile_fields else ("geom_prepared", )
         # limit feature number if limit provided
         limit = self.get_vector_tile_queryset_limit()
         if limit:
             features = features[:limit]
-        # keep values to include in tile (extra included_fields + geometry)
-        features = features.values(*fields)
-        # generate MVT
-        sql, params = features.query.sql_with_params()
+        all_sql = []
+        all_params = []
+        for layer_features, layer_name, extra_fields in self.iter_layer_features(features):
+            fields = (extra_fields or ()) + ("geom_prepared",)
+            # keep values to include in tile (extra included_fields + geometry)
+            layer_features = layer_features.values(*fields)
+            # generate MVT
+            sql, params = layer_features.query.sql_with_params()
+            all_sql.append(sql)
+            all_params.append([
+                layer_name,
+                self.vector_tile_extent,
+                'geom_prepared',
+                *params,
+            ])
         with connection.cursor() as cursor:
-            cursor.execute("SELECT ST_ASMVT(subquery.*, %s, %s, %s) FROM ({}) as subquery".format(sql),
-                           params=[self.get_vector_tile_layer_name(),
-                                   self.vector_tile_extent,
-                                   "geom_prepared",
-                                   *params])
-            row = cursor.fetchone()[0]
-            return row.tobytes() if row else b''
+            sql = ', '.join(
+                "(SELECT ST_ASMVT({}.*, %s, %s, %s) FROM ({}) as {}) AS {}".format(f'q{ii}', sql, f'q{ii}', f'w{ii}')
+                for ii, sql in enumerate(all_sql)
+            )
+            params = sum(all_params, [])
+            cursor.execute(f"SELECT {sql}", params=params)
+            return b''.join((r.tobytes() if r else b'') for r in cursor.fetchone())


### PR DESCRIPTION
When dealing with maps with many layers there can be many API calls,
or, many DB hits depending on how the API is structured. These changes
allow for a single DB hit to fetch and concatenate all required layers
into a single response.

Please note that this work is currently just a proof-of-concept. I
would want to add tests, documentation, and clean up the code a
bit. I'd like to hear back about whether you think this is valuable or
not before comitting to tidying it up. Cheers!