### PR TITLE
call Force2d on geometries passed into AsMVTGeom

### DIFF
--- a/vectortiles/backends/postgis/__init__.py
+++ b/vectortiles/backends/postgis/__init__.py
@@ -22,7 +22,6 @@ class VectorLayer(BaseVectorLayerMixin):
         features = features.annotate(
             geom_prepared=AsMVTGeom(
                 Force2D(Transform(self.geom_field, 3857)),
-                Transform(self.geom_field, 3857),
                 MakeEnvelope(xmin, ymin, xmax, ymax, 3857),
                 self.tile_extent,
                 self.tile_buffer,

--- a/vectortiles/backends/postgis/__init__.py
+++ b/vectortiles/backends/postgis/__init__.py
@@ -2,7 +2,7 @@ from django.contrib.gis.db.models.functions import Transform
 from django.db import connections
 
 from vectortiles.backends import BaseVectorLayerMixin
-from vectortiles.backends.postgis.functions import AsMVTGeom, MakeEnvelope
+from vectortiles.backends.postgis.functions import AsMVTGeom, MakeEnvelope, Force2D
 
 
 class VectorLayer(BaseVectorLayerMixin):
@@ -21,6 +21,7 @@ class VectorLayer(BaseVectorLayerMixin):
         # annotate prepared geometry for MVT
         features = features.annotate(
             geom_prepared=AsMVTGeom(
+                Force2D(Transform(self.geom_field, 3857)),
                 Transform(self.geom_field, 3857),
                 MakeEnvelope(xmin, ymin, xmax, ymax, 3857),
                 self.tile_extent,

--- a/vectortiles/backends/postgis/functions.py
+++ b/vectortiles/backends/postgis/functions.py
@@ -28,3 +28,10 @@ class AsMVTGeom(GeoFunc):
     @cached_property
     def output_field(self):
         return RawGeometryField()
+
+class Force2D(GeoFunc):
+    function = "ST_FORCE2D"
+
+    @cached_property
+    def output_field(self):
+        return RawGeometryField()


### PR DESCRIPTION
I ran into an issue where clipping causes some geometries to be 0d, leading to this error "ERROR: lwcollection_construct: mixed dimension geometries: 2/0". The fix is to call ST_Force2D on the transformed geometry. For more info see  https://github.com/CrunchyData/pg_tileserv/issues/39